### PR TITLE
use shutil.move insted of os.replace

### DIFF
--- a/util/helpers.py
+++ b/util/helpers.py
@@ -3,6 +3,7 @@ Copyright (c) 2019, Brian Stafford
 See LICENSE for details
 """
 import os
+import shutil
 import sys
 import time
 import calendar
@@ -215,4 +216,4 @@ def saveFile(path, contents, binary=False):
             f.write(contents)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(tmpPath, path)
+        shutil.move(tmpPath, path)


### PR DESCRIPTION
os.replace does not work if the source and destination is not in the same file system. 


Eg: "/tmp" might be in a different file system to "~/.local/share/TinyDecred/"


This changes "os.replace" to "shutil.move"